### PR TITLE
Handle `TRACE{PARENT,STATE}` and `BAGGAGE`

### DIFF
--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -14,8 +14,10 @@ extra-doc-files:    CHANGELOG.md
 library
     exposed-modules:  OpenTelemetry.Plugin
     build-depends:    base >=4.15.0.0 && < 5
+                    , bytestring
                     , containers
                     , hs-opentelemetry-api
+                    , hs-opentelemetry-propagator-w3c
                     , hs-opentelemetry-sdk
                     , text
     other-modules:    Paths_opentelemetry_plugin


### PR DESCRIPTION
This allows the GHC plugin to correctly register its spans as the child spans of a parent command if present.  For example, if you run the GHC plugin inside of [a `hotel` command](https://github.com/parsonsmatt/hotel-california) then it will use the `build` span as the parent.

Not only does this connect the two traces but it also fixes the duration of the global span when a parent trace is available.  However, we still have to fall back on a zero-width global span if no parent trace is available.