### PR TITLE
Add support for sampling a subset of module spans

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,18 +3,13 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1695934786,
-        "narHash": "sha256-g38SlwRKWY29/ImD1oO+svzOaCPme1Z7KWR2qmRyaPQ=",
-        "owner": "commercialhaskell",
-        "repo": "all-cabal-hashes",
-        "rev": "c314b1bfabd37d30d2f315a5a322323ebbd98acb",
-        "type": "github"
+        "narHash": "sha256-gEL/53v6/8oU2beexEAKFkZFDoTSbMKia7JZBmE+okM=",
+        "type": "file",
+        "url": "https://api.github.com/repos/commercialhaskell/all-cabal-hashes/tarball/c314b1bfabd37d30d2f315a5a322323ebbd98acb"
       },
       "original": {
-        "owner": "commercialhaskell",
-        "ref": "hackage",
-        "repo": "all-cabal-hashes",
-        "type": "github"
+        "type": "file",
+        "url": "https://api.github.com/repos/commercialhaskell/all-cabal-hashes/tarball/c314b1bfabd37d30d2f315a5a322323ebbd98acb"
       }
     },
     "nixpkgs": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1695875486,
-        "narHash": "sha256-6lMIxBq35IPSRG72w18sVz8yHw8xYusmJv2Sb3DS6v0=",
+        "lastModified": 1695934786,
+        "narHash": "sha256-g38SlwRKWY29/ImD1oO+svzOaCPme1Z7KWR2qmRyaPQ=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "38bf94f1f4a1a791678150696dd0880802d3058b",
+        "rev": "c314b1bfabd37d30d2f315a5a322323ebbd98acb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1695838357,
-        "narHash": "sha256-YoQeViHW2w5Cn3lD3Rq2o2xjyo2xxh8Vt6ut0WcYZNU=",
+        "lastModified": 1695875486,
+        "narHash": "sha256-6lMIxBq35IPSRG72w18sVz8yHw8xYusmJv2Sb3DS6v0=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "4ad8e15d1c8bcc2b4772ca350f971ceb9f812f48",
+        "rev": "38bf94f1f4a1a791678150696dd0880802d3058b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "all-cabal-hashes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695838357,
+        "narHash": "sha256-YoQeViHW2w5Cn3lD3Rq2o2xjyo2xxh8Vt6ut0WcYZNU=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "4ad8e15d1c8bcc2b4772ca350f971ceb9f812f48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "ref": "hackage",
+        "repo": "all-cabal-hashes",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1685566663,
@@ -18,6 +35,7 @@
     },
     "root": {
       "inputs": {
+        "all-cabal-hashes": "all-cabal-hashes",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,22 @@
     nixpkgs.url = "github:NixOS/nixpkgs/23.05";
 
     utils.url = github:numtide/flake-utils;
+
+    all-cabal-hashes = {
+      url = "github:commercialhaskell/all-cabal-hashes/hackage";
+      flake = false;
+    };
   };
 
-  outputs = { nixpkgs, utils, ... }:
+  outputs = { all-cabal-hashes, nixpkgs, utils, ... }:
     utils.lib.eachDefaultSystem (system:
     utils.lib.eachSystem [ "ghc96" ] (compiler:
       let
         config = { };
 
         overlay = self: super: {
+          inherit all-cabal-hashes;
+
           haskell = super.haskell // {
             packages = super.haskell.packages // {
               "${compiler}" = super.haskell.packages."${compiler}".override (old: {
@@ -19,6 +26,16 @@
                     self.lib.composeExtensions
                     (_: _: { })
                     [ (self.haskell.lib.packageSourceOverrides {
+                        hs-opentelemetry-api = "0.1.0.0";
+
+                        hs-opentelemetry-exporter-otlp = "0.0.1.5";
+
+                        hs-opentelemetry-propagator-b3 = "0.0.1.1";
+
+                        hs-opentelemetry-propagator-w3c = "0.0.1.3";
+
+                        hs-opentelemetry-sdk = "0.0.3.6";
+
                         opentelemetry-plugin =
                           self.lib.cleanSourceWith
                             { filter = name: type:

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,8 @@
     utils.url = github:numtide/flake-utils;
 
     all-cabal-hashes = {
-      url = "github:commercialhaskell/all-cabal-hashes/hackage";
+      url = "https://api.github.com/repos/commercialhaskell/all-cabal-hashes/tarball/c314b1bfabd37d30d2f315a5a322323ebbd98acb";
+      type = "file";
       flake = false;
     };
   };

--- a/ghc96/OpenTelemetry/Plugin.hs
+++ b/ghc96/OpenTelemetry/Plugin.hs
@@ -41,7 +41,7 @@ wrapTodo getParentContext todo =
                     Outputable.showSDocOneLine Outputable.defaultSDocContext sdoc
 
             (_, beginPass, endPass) <- do
-                Shared.makeWrapperPluginPasses getParentContext (Text.pack label)
+                Shared.makeWrapperPluginPasses False getParentContext (Text.pack label)
 
             let beginPluginPass =
                     CoreDoPluginPass ("begin " <> label) \modGuts -> liftIO do
@@ -86,7 +86,7 @@ plugin =
         let moduleText = Text.pack (Plugins.moduleNameString moduleName_)
 
         (getCurrentContext, firstPluginPass, lastPluginPass) <- do
-            liftIO (Shared.makeWrapperPluginPasses Shared.getTopLevelContext moduleText)
+            liftIO (Shared.makeWrapperPluginPasses True Shared.getTopLevelContext moduleText)
 
         let firstPass =
                 CoreDoPluginPass "begin module" \modGuts -> liftIO do

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -17,10 +17,12 @@ library
     build-depends:    base >=4.15.0.0 && < 5
                     , bytestring
                     , containers
-                    , hs-opentelemetry-api
+                    , hs-opentelemetry-api >= 0.1.0.0
                     , hs-opentelemetry-propagator-w3c
                     , hs-opentelemetry-sdk
+                    , mwc-random
                     , text
+                    , unordered-containers
     other-modules:    OpenTelemetry.Plugin.Shared
                     , Paths_opentelemetry_plugin
     autogen-modules:  Paths_opentelemetry_plugin

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -72,7 +72,8 @@ import qualified Text.Read as Read
     but none of the stock samplers provide a way to sample a subset of
     the `Span`s within a trace.
 
-    This adds a new "sampler
+    This adds a new "spanratio" sampler which can be used to sample subset of
+    module spans.
 -}
 getSampler :: IO (Maybe Sampler)
 getSampler = do

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -23,6 +23,8 @@ module OpenTelemetry.Plugin.Shared
 
       -- * Flushing
     , flush
+
+    , getSampler
     ) where
 
 import Control.Concurrent.MVar (MVar)
@@ -31,17 +33,24 @@ import Data.ByteString (ByteString)
 import Data.Set (Set)
 import Data.Text (Text)
 import OpenTelemetry.Context (Context)
+import OpenTelemetry.Trace.Sampler (Sampler(..), SamplingResult(..))
 import Prelude hiding (span)
+import System.Random.MWC (GenIO)
 
 import OpenTelemetry.Trace
-    ( InstrumentationLibrary(..)
+    ( Attribute(..)
+    , PrimitiveAttribute(..)
+    , InstrumentationLibrary(..)
     , Span
     , SpanArguments(..)
+    , SpanContext(..)
     , Tracer
     , TracerProvider
+    , TracerProviderOptions(..)
     )
 
 import qualified Control.Concurrent.MVar as MVar
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text.Encoding
@@ -51,9 +60,64 @@ import qualified OpenTelemetry.Propagator.W3CBaggage as W3CBaggage
 import qualified OpenTelemetry.Propagator.W3CTraceContext as W3CTraceContext
 import qualified OpenTelemetry.Trace as Trace
 import qualified OpenTelemetry.Trace.Core as Trace.Core
+import qualified OpenTelemetry.Trace.Sampler as Sampler
+import qualified OpenTelemetry.Trace.TraceState as TraceState
 import qualified Paths_opentelemetry_plugin as Paths
 import qualified System.Environment as Environment
 import qualified System.IO.Unsafe as Unsafe
+import qualified System.Random.MWC as MWC
+import qualified Text.Read as Read
+
+{-| Very large Haskell builds can generate an enormous number of spans,
+    but none of the stock samplers provide a way to sample a subset of
+    the `Span`s within a trace.
+
+    This adds a new "sampler
+-}
+getSampler :: IO (Maybe Sampler)
+getSampler = do
+    maybeSampler <- Environment.lookupEnv "OTEL_TRACES_SAMPLER"
+
+    maybeRatio <- Environment.lookupEnv "OTEL_TRACES_SAMPLER_ARG"
+
+    pure do
+        "spanratio" <- maybeSampler
+        ratioString <- maybeRatio
+        ratio <- Read.readMaybe ratioString
+        pure (spanRatioBased ratio)
+
+{-| Like a lot of other uses of `unsafePerformIO` in this module, we're doing
+    this because the plugin interface doesn't provide a way for us to acquire
+    resources before returning the plugin.
+-}
+generator :: GenIO
+generator = Unsafe.unsafePerformIO MWC.createSystemRandom
+{-# NOINLINE generator #-}
+
+spanRatioBased :: Double -> Sampler
+spanRatioBased fraction = Sampler
+    { getDescription =
+          "SpanRatioBased{" <> Text.pack (show fraction) <> "}"
+    , shouldSample = \context traceId_ name spanArguments -> do
+        case HashMap.lookup "sample" (attributes spanArguments) of
+            Just (AttributeValue (BoolAttribute True)) -> do
+                random <- MWC.uniformR (0, 1) generator
+
+                let samplingResult =
+                        if random < fraction then RecordAndSample else Drop
+
+                traceState_ <- case Context.lookupSpan context of
+                    Nothing ->
+                        pure TraceState.empty
+
+                    Just span ->
+                        fmap traceState (Trace.Core.getSpanContext span)
+
+                pure (samplingResult, HashMap.empty, traceState_)
+
+            _ ->
+                shouldSample Sampler.alwaysOn context traceId_ name spanArguments
+    }
 
 {-| Note: We don't properly shut this down using `shutdownTracerProvider`, but
     all that the shutdown does is flush metrics, so instead we flush metrics
@@ -61,7 +125,21 @@ import qualified System.IO.Unsafe as Unsafe
     proper shutdown.
 -}
 tracerProvider :: TracerProvider
-tracerProvider = Unsafe.unsafePerformIO Trace.initializeGlobalTracerProvider
+tracerProvider = Unsafe.unsafePerformIO do
+    (processors, options) <- Trace.getTracerProviderInitializationOptions
+
+    maybeSampler <- getSampler
+
+    let newOptions =
+            case maybeSampler of
+                Nothing      -> options
+                Just sampler -> options{ tracerProviderOptionsSampler = sampler }
+
+    tracerProvider_ <- Trace.createTracerProvider processors newOptions
+
+    Trace.setGlobalTracerProvider tracerProvider_
+
+    pure tracerProvider_
 {-# NOINLINE tracerProvider #-}
 
 tracer :: Tracer
@@ -83,19 +161,31 @@ tracer =
     `Context`).
 -}
 makeWrapperPluginPasses
-    :: IO Context
+    :: Bool
+      -- ^ Whether to sample a subset of spans
+    -> IO Context
        -- ^ Action to ead the parent span's `Context`
     -> Text
        -- ^ Label for the current span
     -> IO (IO Context, IO (), IO ())
-makeWrapperPluginPasses getParentContext label = liftIO do
+makeWrapperPluginPasses sample getParentContext label = liftIO do
     spanMVar           <- liftIO MVar.newEmptyMVar
     currentContextMVar <- liftIO MVar.newEmptyMVar
 
     let beginPass = do
             parentContext <- getParentContext
 
-            passSpan <- Trace.createSpan tracer parentContext label Trace.defaultSpanArguments
+            let spanArguments =
+                    if sample
+                    then
+                        Trace.defaultSpanArguments
+                            { attributes =
+                                HashMap.singleton "sample" (AttributeValue (BoolAttribute True))
+                            }
+                    else
+                        Trace.defaultSpanArguments
+
+            passSpan <- Trace.createSpan tracer parentContext label spanArguments
 
             MVar.putMVar spanMVar passSpan
 
@@ -122,9 +212,9 @@ topLevelContextMVar = Unsafe.unsafePerformIO MVar.newEmptyMVar
 getTopLevelSpan :: IO Span
 getTopLevelSpan = do
     traceParent <- lookupEnv "TRACEPARENT"
-    traceState  <- lookupEnv "TRACESTATE"
+    traceState_ <- lookupEnv "TRACESTATE"
 
-    case W3CTraceContext.decodeSpanContext traceParent traceState of
+    case W3CTraceContext.decodeSpanContext traceParent traceState_ of
         Just spanContext ->
             pure (Trace.Core.wrapSpanContext spanContext)
 


### PR DESCRIPTION
In our internal codebase we have 6000+ modules which each generate a span and we also typically have two compiler phases per module which each generate two sub-spans, so we generate roughly 3 × 6000+ = 18000+ spans that we export as part of each trace if we don't do any sampling.

Unfortunately, Honeycomb cannot render a trace with 18000 spans, so we need some way to sample a random subset of them so that we can still get some useful insights about our build.

Fortunately, open telemetry does support sampling things, but none of the stock samplers work for our use case.  In particular, the only relevant sampler that open telemetry provides out of the box is a `traceidratio` sampler which samples a subset of traces (but not spans), so that wouldn't really fix our problem.

So what I did was have our plugin interpret an optional `spanratio` sampler which can be configured through the standard `OTEL_TRACES_SAMPLER{,_ARG}` environment variables:

https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration

So now if you export something like:

```bash
OTEL_TRACES_SAMPLER=spanratio
OTEL_TRACES_SAMPLER_ARG=0.1
```

… then the plugin will sample 10% of all modules.

Note that we don't apply the span ratio to sub-spans of a module (which would generate weird traces) and we don't apply the span ratio to the root span that envelopes the entire trace (because then you'd drop a whole lot of traces).  We only apply the span ratio to the module-wide spans.

Note that this required upgrading the `hs-opentelemetry-api` dependency because the latest version changed the API of the `attributes` field of `SpanArguments` and I'm only really interested in supporting the latest version of the API and not older versions.  That's why the `hs-opentelemetry-api` now has a lower bound, too.