### PR TITLE
Don't collect CLI args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -127,7 +127,13 @@ spanRatioBased fraction = Sampler
 -}
 tracerProvider :: TracerProvider
 tracerProvider = Unsafe.unsafePerformIO do
-    (processors, options) <- Trace.getTracerProviderInitializationOptions
+    (processors, options) <-
+        -- This function will collect *all* of the command line arguments
+        -- that were provided to GHC. This results in a huge amount of data
+        -- being sent. For that reason, we blank out the process arguments
+        -- for this section of code.
+        Environment.withArgs [] do
+            Trace.getTracerProviderInitializationOptions
 
     maybeSampler <- getSampler
 


### PR DESCRIPTION
The `hs-opentelemetry` library will call `getArgs` when discovering the process environment. `cabal` will invoke GHC with a *huge* amount of arguments. The work codebase is apparently sending something like 64KB per span, resulting in almost 2.6GB of data *per build*.

This PR does `withArgs []` before that call, which will remove that overhead.