### PR TITLE
Configurable compilation pass spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+- You can now set `OTEL_GHC_PLUGIN_RECORD_PASSES` to have the plugin report
+  spans for compilation passes. By default, it will only record the
+  module-level spans. By setting it to `t` or `true`, it will record the same level of granularity as the prior version.
+
 # 1.0.0
 
 - Initial release

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               opentelemetry-plugin
-version:            1.0.0
+version:            1.1.0
 synopsis:           GHC plugin for open telemetry
 description:        This package provides a GHC plugin that exports each module's build times to an open telemetry collector.  See the included `README` below for more details.
 license:            BSD-3-Clause

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -116,7 +116,7 @@ plugin =
 
                     pure modGuts
 
-        shouldMakeSubPasses <- Shared.getPluginShouldRecordPasses
+        shouldMakeSubPasses <- liftIO Shared.getPluginShouldRecordPasses
 
         newTodos <-
             if shouldMakeSubPasses

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -116,7 +116,12 @@ plugin =
 
                     pure modGuts
 
-        newTodos <- traverse (wrapTodo getCurrentContext) todos
+        shouldMakeSubPasses <- Shared.getPluginShouldRecordPasses
+
+        newTodos <-
+            if shouldMakeSubPasses
+            then traverse (wrapTodo getCurrentContext) todos
+            else pure todos
 
         pure ([ firstPass ] <> newTodos <> [ lastPass ])
 

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -171,7 +171,7 @@ makeWrapperPluginPasses
     :: Bool
       -- ^ Whether to sample a subset of spans
     -> IO Context
-       -- ^ Action to ead the parent span's `Context`
+       -- ^ Action to read the parent span's `Context`
     -> Text
        -- ^ Label for the current span
     -> IO (IO Context, IO (), IO ())
@@ -332,3 +332,16 @@ flush = do
     _ <- Trace.Core.forceFlushTracerProvider tracerProvider Nothing
 
     pure ()
+
+-- | Returns 'True' if the plugin should create spans for module passes in
+-- compilation. Examples would be Simplifier, any other plugin execution,
+-- etc.
+getPluginShouldRecordPasses :: IO Bool
+getPluginShouldRecordPasses = do
+    maybeRecordPasses <- Environment.lookupEnv "OTEL_GHC_PLUGIN_RECORD_PASSES"
+    pure $ fromMaybe False do
+        recordPassess <- maybeRecordPasses
+        asum
+            [ True <$ stripPrefix "t" recordPasses
+            , (> 0) <$> readMaybe recordPasses
+            ]

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -344,7 +344,4 @@ getPluginShouldRecordPasses = do
     maybeRecordPasses <- Environment.lookupEnv "OTEL_GHC_PLUGIN_RECORD_PASSES"
     pure $ Maybe.fromMaybe False do
         recordPasses <- maybeRecordPasses
-        Monad.msum
-            [ True <$ Text.stripPrefix "t" (Text.toLower (Text.strip (Text.pack recordPasses)))
-            , ((0 :: Int) <) <$> Read.readMaybe recordPasses
-            ]
+        pure $ Text.toLower (Text.pack recordPasses) `elem` ["true", "t"]


### PR DESCRIPTION
This PR adds support for reading an environment variable `OTEL_GHC_PLUGIN_RECORD_PASSES` which allows the user to configure whether or not to record spans for each sub-pass.

For motivation: our ~7k module codebase is emitting ~21k spans per complete build. Over the last two weeks, our lint plugin and `Simplifier` represent about 500k spans per day, each, which is eating into our Honeycomb budget. Implementing this flag will save us about 1M spans per day, and more if we continue to increase adoption of Honeycomb tracing.