### PR TITLE
Create and close span in runPhaseHook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.0
+
+- The plugin now records much more of the module's compilation. Previously, the
+  span was only recording the `installCoreToDos` phase. With this version, we
+  record starting at the very beginning of compilation (before parsing,
+  TemplateHaskell, etc), and we stop recording at the end of all linking steps.
+- GHC support for < 9.6 was dropped. Further patches should restore this
+  support if desired. 
+
 # 1.1.0
 
 - You can now set `OTEL_GHC_PLUGIN_RECORD_PASSES` to have the plugin report

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
 
   outputs = { all-cabal-hashes, nixpkgs, utils, ... }:
     utils.lib.eachDefaultSystem (system:
-    utils.lib.eachSystem [ "ghc92" "ghc94" "ghc96" ] (compiler:
+    utils.lib.eachSystem [ "ghc96" "ghc98" ] (compiler:
       let
         config = { };
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
 
   outputs = { all-cabal-hashes, nixpkgs, utils, ... }:
     utils.lib.eachDefaultSystem (system:
-    utils.lib.eachSystem [ "ghc96" ] (compiler:
+    utils.lib.eachSystem [ "ghc96" "ghc98" ] (compiler:
       let
         config = { };
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
 
   outputs = { all-cabal-hashes, nixpkgs, utils, ... }:
     utils.lib.eachDefaultSystem (system:
-    utils.lib.eachSystem [ "ghc96" "ghc98" ] (compiler:
+    utils.lib.eachSystem [ "ghc96" ] (compiler:
       let
         config = { };
 

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -25,6 +25,7 @@ library
                     , stm
                     , stm-containers
                     , text
+                    , transformers
                     , unordered-containers
     other-modules:    OpenTelemetry.Plugin.Shared
                     , Paths_opentelemetry_plugin

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -31,3 +31,16 @@ library
     autogen-modules:  Paths_opentelemetry_plugin
     default-language: Haskell2010
     ghc-options:      -Wall
+
+test-suite tests
+    type:           exitcode-stdio-1.0
+    ghc-options:
+      -Wall -threaded -rtsopts 
+      -fplugin OpenTelemetry.Plugin -plugin-package opentelemetry-plugin
+  
+    build-depends:
+        base
+  
+    hs-source-dirs: test
+    main-is:        Main.hs
+  

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -14,7 +14,7 @@ extra-doc-files:    CHANGELOG.md README.md
 library
     hs-source-dirs:   src
     exposed-modules:  OpenTelemetry.Plugin
-    build-depends:    base >=4.15.0.0 && < 5
+    build-depends:    base >=4.18.0.0 && < 5
                     , bytestring
                     , containers
                     , ghc >= 9.2 && < 9.8

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -22,6 +22,8 @@ library
                     , hs-opentelemetry-propagator-w3c
                     , hs-opentelemetry-sdk >= 0.0.3.0 && < 0.1
                     , mwc-random >= 0.13.1.0
+                    , stm
+                    , stm-containers
                     , text
                     , unordered-containers
     other-modules:    OpenTelemetry.Plugin.Shared

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -32,16 +32,3 @@ library
     autogen-modules:  Paths_opentelemetry_plugin
     default-language: Haskell2010
     ghc-options:      -Wall
-
-test-suite tests
-    type:           exitcode-stdio-1.0
-    ghc-options:
-      -Wall -threaded -rtsopts 
-      -fplugin OpenTelemetry.Plugin -plugin-package opentelemetry-plugin
-  
-    build-depends:
-        base
-  
-    hs-source-dirs: test
-    main-is:        Main.hs
-  

--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               opentelemetry-plugin
-version:            1.1.0
+version:            1.2.0
 synopsis:           GHC plugin for open telemetry
 description:        This package provides a GHC plugin that exports each module's build times to an open telemetry collector.  See the included `README` below for more details.
 license:            BSD-3-Clause

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -153,6 +153,7 @@ tphase2Text p =
     T_LlvmLlc {} -> "T_LlvmLlc"
     T_LlvmMangle {} -> "T_LlvmMangle"
     T_MergeForeign {} -> "T_MergeForeign"
+    _ -> "Unknown Phase"
 
 -- return an ident of some sort for the phase
 envFromTPhase :: TPhase res -> Maybe String
@@ -168,9 +169,10 @@ envFromTPhase p =
     T_HscBackend _ _ mname _ _ _ -> Just (Plugins.moduleNameString mname)
     T_CmmCpp _ _ outputFilepath -> Just outputFilepath
     T_Cmm _ _ outputFilepath -> Just outputFilepath
-    T_Cc _ _ _ outputFilepath -> Just outputFilepath
+    T_Cc _ _ _ _ outputFilepath -> Just outputFilepath
     T_As _ _ _ _ _ -> (Nothing)
     T_LlvmOpt _ _ _ -> (Nothing)
     T_LlvmLlc _ _ _ -> (Nothing)
     T_LlvmMangle _ _ _ -> (Nothing)
     T_MergeForeign _ _ objectFilePath _ -> Just objectFilePath
+    _ -> Nothing

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -109,7 +109,7 @@ plugin =
                                     x <- runPhase phase
                                     case closePhase of
                                         CloseInMergeForeign ->
-                                            Shared.recordModuleEndFromObjectFilepath objectFilePath
+                                            Shared.recordModuleEnd objectFilePath
                                         _ ->
                                             pure ()
                                     pure x
@@ -119,7 +119,7 @@ plugin =
                                     x <- runPhase phase
                                     case closePhase of
                                         CloseInHscBackend ->
-                                            Shared.recordModuleEndFromModuleName (Plugins.moduleNameString modName)
+                                            Shared.recordModuleEnd (Plugins.moduleNameString modName)
                                         _ ->
                                             pure ()
                                     pure x

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -100,15 +100,13 @@ plugin =
                                     -- create span for module name
                                     context <- Shared.getTopLevelContext
                                     span_ <- Trace.createSpan Shared.tracer context (Text.pack modName) Trace.defaultSpanArguments
-                                    print ("modObjectLocation: ", modObjectLocation)
+                                    -- print ("modObjectLocation: ", modObjectLocation)
                                     STM.atomically $ StmMap.insert span_ modObjectLocation spanMap
                                     runPhase phase
                                 T_MergeForeign _pipeEnv _hscEnv filePath _filePaths -> do
                                     -- the filepath here points to a .dyn_o
-                                    -- object. which. fortunately. has the
-                                    -- name of the module infixed! just
-                                    -- need to take the
-                                    print ("MergeForeign filepath: ", filePath)
+                                    -- object. we can use this.
+                                    -- print ("MergeForeign filepath: ", filePath)
                                     mspan <- STM.atomically $ StmMap.lookup filePath stmMap
                                     for_ mspan $ \span_ -> Trace.endSpan span_ Nothing
                                     x <- runPhase phase

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -119,7 +119,6 @@ plugin =
                                             pure ()
                                     pure x
                                 _ -> do
-                                    print (tphase2Text phase, envFromTPhase phase)
 
                                     runPhase phase
                     }
@@ -157,46 +156,3 @@ plugin =
     pluginRecompile = Plugins.purePlugin
 
 data ClosePhase = CloseInHscBackend | CloseInMergeForeign
-
-tphase2Text :: TPhase res -> String
-tphase2Text p =
-  case p of
-    T_Unlit {} -> "T_Unlit"
-    T_FileArgs {} -> "T_FileArgs"
-    T_Cpp {} -> "T_Cpp"
-    T_HsPp {} -> "T_HsPp"
-    T_HscRecomp {} -> "T_HsRecomp"
-    T_Hsc {} -> "T_Hsc"
-    T_HscPostTc {} -> "T_HscPostTc"
-    T_HscBackend {} -> "T_HscBackend"
-    T_CmmCpp {} -> "T_CmmCpp"
-    T_Cmm {} -> "T_Cmm"
-    T_Cc {} -> "T_Cc"
-    T_As {} -> "T_As"
-    T_LlvmOpt {} -> "T_LlvmOpt"
-    T_LlvmLlc {} -> "T_LlvmLlc"
-    T_LlvmMangle {} -> "T_LlvmMangle"
-    T_MergeForeign {} -> "T_MergeForeign"
-    _ -> "Unknown Phase"
-
--- return an ident of some sort for the phase
-envFromTPhase :: TPhase res -> Maybe String
-envFromTPhase p =
-  case p of
-    T_Unlit _ _ _ -> Nothing
-    T_FileArgs _ _ -> Nothing
-    T_Cpp _ _ _ -> Nothing
-    T_HsPp _ _ _ _ -> Nothing
-    T_HscRecomp _ _ filepath _ -> Just filepath
-    T_Hsc _ modSummary -> Just (Shared.getModuleNameFromSummary modSummary)
-    T_HscPostTc _ modSummary _ _ _ -> Just (Shared.getModuleNameFromSummary modSummary)
-    T_HscBackend _ _ mname _ _ _ -> Just (Plugins.moduleNameString mname)
-    T_CmmCpp _ _ outputFilepath -> Just outputFilepath
-    T_Cmm _ _ outputFilepath -> Just outputFilepath
-    T_Cc _ _ _ _ outputFilepath -> Just outputFilepath
-    T_As _ _ _ _ _ -> (Nothing)
-    T_LlvmOpt _ _ _ -> (Nothing)
-    T_LlvmLlc _ _ _ -> (Nothing)
-    T_LlvmMangle _ _ _ -> (Nothing)
-    T_MergeForeign _ _ objectFilePath _ -> Just objectFilePath
-    _ -> Nothing

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -16,8 +16,8 @@ module OpenTelemetry.Plugin
 import Control.Monad.IO.Class (MonadIO(..))
 import GHC.Types.Target (Target(..), TargetId(..))
 import OpenTelemetry.Context (Context)
-import GHC.Driver.Pipeline (runPhase)
 
+import GHC.Driver.Pipeline (runPhase)
 import GHC.Driver.Pipeline.Phases
   ( PhaseHook (..),
     TPhase (..),

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -65,7 +65,7 @@ wrapTodo getParentContext todo =
 
                         pure modGuts
 
-            pure (CoreDoPasses [ beginPluginPass, todo, endPluginPass ])
+            pure (CoreDoPasses [beginPluginPass, todo, endPluginPass ])
 
 -- | GHC plugin that exports open telemetry metrics about the build
 plugin :: Plugin
@@ -107,9 +107,9 @@ plugin =
                                     -- the filepath here points to a .dyn_o
                                     -- object. we can use this.
                                     -- print ("MergeForeign filepath: ", filePath)
+                                    x <- runPhase phase
                                     mspan <- STM.atomically $ StmMap.lookup filePath spanMap
                                     Monad.forM_ mspan $ \span_ -> Trace.endSpan span_ Nothing
-                                    x <- runPhase phase
                                     -- close span for module name
                                     pure x
 

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -25,7 +25,6 @@ import GHC.Driver.Pipeline.Phases
 import GHC.Driver.Hooks (Hooks (..))
 import GHC.Plugins
     ( CoreToDo(..)
-    , GenModule(..)
     , HscEnv(..)
     , Plugin(..)
     )
@@ -61,7 +60,7 @@ wrapTodo getParentContext todo =
 
                         pure modGuts
 
-            pure (CoreDoPasses [beginPluginPass, todo, endPluginPass ])
+            pure (CoreDoPasses [ beginPluginPass, todo, endPluginPass ])
 
 -- | GHC plugin that exports open telemetry metrics about the build
 plugin :: Plugin
@@ -107,14 +106,10 @@ plugin =
             then do
                 module_ <- Plugins.getModule
 
-                let moduleName_ = moduleName module_
-
-                let moduleText = Text.pack (Plugins.moduleNameString moduleName_)
-
                 (getCurrentContext, firstPluginPass, lastPluginPass) <- do
                     let getContext =
                             Shared.modifyContextWithParentSpan module_ Shared.getTopLevelContext
-                    liftIO (Shared.makeWrapperPluginPasses True getContext moduleText)
+                    liftIO (Shared.makeWrapperPluginPasses True getContext "CoreToDos")
 
                 let firstPass =
                         CoreDoPluginPass "begin module" \modGuts -> liftIO do

--- a/src/OpenTelemetry/Plugin.hs
+++ b/src/OpenTelemetry/Plugin.hs
@@ -107,8 +107,8 @@ plugin =
                                     -- the filepath here points to a .dyn_o
                                     -- object. we can use this.
                                     -- print ("MergeForeign filepath: ", filePath)
-                                    mspan <- STM.atomically $ StmMap.lookup filePath stmMap
-                                    for_ mspan $ \span_ -> Trace.endSpan span_ Nothing
+                                    mspan <- STM.atomically $ StmMap.lookup filePath spanMap
+                                    Monad.forM_ mspan $ \span_ -> Trace.endSpan span_ Nothing
                                     x <- runPhase phase
                                     -- close span for module name
                                     pure x

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -210,7 +210,7 @@ makeWrapperPluginPasses sample getParentContext label = liftIO do
                     else
                         Trace.defaultSpanArguments
 
-            passSpan <- Trace.createSpan tracer parentContext ("OG: " <> label) spanArguments
+            passSpan <- Trace.createSpan tracer parentContext label spanArguments
 
             _ <- MVar.tryPutMVar spanMVar passSpan
 

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -196,7 +196,7 @@ makeWrapperPluginPasses sample getParentContext label = liftIO do
                     else
                         Trace.defaultSpanArguments
 
-            passSpan <- Trace.createSpan tracer parentContext label spanArguments
+            passSpan <- Trace.createSpan tracer parentContext ("OG: " <> label) spanArguments
 
             _ <- MVar.tryPutMVar spanMVar passSpan
 

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -238,7 +238,7 @@ topLevelContextMVar :: MVar Context
 topLevelContextMVar = Unsafe.unsafePerformIO MVar.newEmptyMVar
 {-# NOINLINE topLevelContextMVar #-}
 
-{- | We keep track of the module spans in this top-level 'IORef' so that it
+{- | We keep track of the module spans in this top-level 'MVar' so that it
      may be shared between the driverPlugin and other plugins.
 
 -}

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -25,6 +25,7 @@ module OpenTelemetry.Plugin.Shared
     , flush
 
     , getSampler
+    , tracer
     ) where
 
 import Control.Concurrent.MVar (MVar)

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -31,6 +31,8 @@ module OpenTelemetry.Plugin.Shared
     , getSampler
     , tracer
 
+    , getModuleName
+
     -- * Recording spans in 'runPhaseHook'
     , SpanMap
     , newSpanMap
@@ -417,12 +419,16 @@ data ModuleSpan = ModuleSpan
 newSpanMap :: IO SpanMap
 newSpanMap = MkSpanMap <$> StmMap.newIO <*> StmMap.newIO
 
+getModuleName :: Plugins.ModSummary -> String
+getModuleName =
+    Plugins.moduleNameString . Plugins.moduleName . Plugins.ms_mod
+
 -- | Create a 'Span' for the given 'ModSummary' and record it in the
 -- 'SpanMap'.
 recordModuleStart :: Plugins.ModSummary -> IO ()
 recordModuleStart modSummary = do
     let modName =
-            Plugins.moduleNameString $ Plugins.moduleName $ Plugins.ms_mod modSummary
+            getModuleName modSummary
         modObjectLocation =
             Plugins.ml_obj_file $ Plugins.ms_location modSummary
     putStrLn ("recordModuleStart: \t" <> modName)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,0 @@
-module Main where
-
-main :: IO ()
-main = do
-    pure ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+main :: IO ()
+main = do
+    pure ()


### PR DESCRIPTION
This PR moves the top-level span for a module to the `HscEnv`'s `PhaseHook`, which captures more of the time spent in compilation.

The previous implementation wrapped the `installCoreTodos` phase of compilation only. Figuring out how to capture more time in compilation was surprisingly hard - big thanks to @wavewave for guiding me through the plugin architecture and the `PhaseHook` machinery.

Fortunately, there's one piece of information shared between the start and end phases: the location of the object file to generate. I tested this out and it works in `ghci` and a regular build.

Closes #11 
Closes #13 