### PR TITLE
Bump otel version and use new instrumentation library util

### DIFF
--- a/opentelemetry-plugin.cabal
+++ b/opentelemetry-plugin.cabal
@@ -18,9 +18,9 @@ library
                     , bytestring
                     , containers
                     , ghc >= 9.2 && < 9.8
-                    , hs-opentelemetry-api >= 0.1.0.0 && < 0.2
+                    , hs-opentelemetry-api >= 0.2.0.0 && < 0.4
                     , hs-opentelemetry-propagator-w3c
-                    , hs-opentelemetry-sdk >= 0.0.3.0 && < 0.1
+                    , hs-opentelemetry-sdk >= 0.1.0.0 && < 0.2
                     , mwc-random >= 0.13.1.0
                     , stm
                     , stm-containers

--- a/src/OpenTelemetry/Plugin/Shared.hs
+++ b/src/OpenTelemetry/Plugin/Shared.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE BlockArguments    #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving    #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-| This module provides the GHC-API-agnostic logic for this plugin (mostly
     open telemetry utilities)
@@ -173,13 +174,7 @@ tracerProvider = Unsafe.unsafePerformIO do
 
 tracer :: Tracer
 tracer =
-    Trace.makeTracer tracerProvider instrumentationLibrary Trace.tracerOptions
-  where
-    instrumentationLibrary =
-        InstrumentationLibrary
-            { libraryName    = "opentelemetry-plugin"
-            , libraryVersion = Text.pack (Version.showVersion Paths.version)
-            }
+    Trace.makeTracer tracerProvider $(detectInstrumentationLibrary) Trace.tracerOptions
 
 {-| This used by the GHC plugin to create two plugin passes that start and stop
     a `Span`, respectively.


### PR DESCRIPTION
The shape of `InstrumentationLibrary` changed to add a few additional fields, so fix the library to compile with newer OTel package versions.